### PR TITLE
needed absolute path to pwd for watch/restart events

### DIFF
--- a/forever.js
+++ b/forever.js
@@ -1,6 +1,8 @@
 var forever = require('forever-monitor');
+var pwd = process.cwd();
 
 var child = new (forever.Monitor)('./bin/www', {
+  'cwd': pwd,
   'killTree': true,
   'logFile': 'logs/log',
   'outFile': 'logs/out',
@@ -8,13 +10,26 @@ var child = new (forever.Monitor)('./bin/www', {
   'minUptime': 500,
   'spinSleepTime': 1000,
   'silent': false,
+  'sourceDir': pwd,
   'watch': true,
-  'watchDirectory': '.',
+  'watchDirectory': pwd,
   'watchIgnoreDotFiles': true,
+  'watchIgnorePatterns': [
+    'forever.js',
+  ],
+
 });
 
 child.on('start', function() {
   console.log('forever start');
+});
+
+child.on('restart', function() {
+  console.log(`forever restart #${child.times}`);
+});
+
+child.on('watch:restart', function(info) {
+  console.log('forever watch:restart', info.stat, info.file);
 });
 
 child.start();


### PR DESCRIPTION
Some forever logging issues noted in #2 addressed by configuring `sourceDir` and `sourceDir` options with an absolute path to the project, approximated here by the process' current working directory, `process.cwd()`.